### PR TITLE
reverse if statement to reduce cyclomatic complexity

### DIFF
--- a/ServiceWorkerCronJobDemo/Services/CronJobService.cs
+++ b/ServiceWorkerCronJobDemo/Services/CronJobService.cs
@@ -27,32 +27,35 @@ namespace ServiceWorkerCronJobDemo.Services
         protected virtual async Task ScheduleJob(CancellationToken cancellationToken)
         {
             var next = _expression.GetNextOccurrence(DateTimeOffset.Now, _timeZoneInfo);
-            if (next.HasValue)
+            if (!next.HasValue)
             {
-                var delay = next.Value - DateTimeOffset.Now;
-                if (delay.TotalMilliseconds <= 0)   // prevent non-positive values from being passed into Timer
-                {
-                    await ScheduleJob(cancellationToken);
-                }
-                _timer = new System.Timers.Timer(delay.TotalMilliseconds);
-                _timer.Elapsed += async (sender, args) =>
-                {
-                    _timer.Dispose();  // reset and dispose timer
-                    _timer = null;
-
-                    if (!cancellationToken.IsCancellationRequested)
-                    {
-                        await DoWork(cancellationToken);
-                    }
-
-                    if (!cancellationToken.IsCancellationRequested)
-                    {
-                        await ScheduleJob(cancellationToken);    // reschedule next
-                    }
-                };
-                _timer.Start();
+                return;
             }
-            await Task.CompletedTask;
+            
+            var delay = next.Value - DateTimeOffset.Now;
+            if (delay.TotalMilliseconds <= 0)   // prevent non-positive values from being passed into Timer
+            {
+                await ScheduleJob(cancellationToken);
+            }
+            
+            _timer = new System.Timers.Timer(delay.TotalMilliseconds);
+            _timer.Elapsed += async (sender, args) =>
+            {
+                _timer.Dispose();  // reset and dispose timer
+                _timer = null;
+
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    await DoWork(cancellationToken);
+                }
+
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    await ScheduleJob(cancellationToken);    // reschedule next
+                }
+            };
+            
+            _timer.Start();
         }
 
         public virtual async Task DoWork(CancellationToken cancellationToken)
@@ -60,10 +63,10 @@ namespace ServiceWorkerCronJobDemo.Services
             await Task.Delay(5000, cancellationToken);  // do the work
         }
 
-        public virtual async Task StopAsync(CancellationToken cancellationToken)
+        public virtual Task StopAsync(CancellationToken cancellationToken)
         {
             _timer?.Stop();
-            await Task.CompletedTask;
+            return Task.CompletedTask;
         }
 
         public virtual void Dispose()


### PR DESCRIPTION
* return `Task.CompletedTask` directly instead of `await`ing it
* turn `if (expression)` to `if (!expression)` and early-return
* remove unnecessary `await Task.CompletedTask` call at end of method