### PR TITLE
Return directly after completing the recursive call.

### DIFF
--- a/ServiceWorkerCronJobDemo/Services/CronJobService.cs
+++ b/ServiceWorkerCronJobDemo/Services/CronJobService.cs
@@ -21,6 +21,7 @@ namespace ServiceWorkerCronJobDemo.Services
                 if (delay.TotalMilliseconds <= 0)   // prevent non-positive values from being passed into Timer
                 {
                     await ScheduleJob(cancellationToken);
+                    return;
                 }
                 _timer = new System.Timers.Timer(delay.TotalMilliseconds);
                 _timer.Elapsed += async (_, _) =>


### PR DESCRIPTION
When `delay.TotalMilliseconds` is a negative value, after completing the recursive call to ScheduleJob, if not returning, the negative value will still be passed to the constructor of System.Timers.Timer, thereby causing an exception.